### PR TITLE
Feat/#48 로그인핸들러추가

### DIFF
--- a/api/core.ts
+++ b/api/core.ts
@@ -1,6 +1,6 @@
 import axios, {
-  type AxiosInstance, 
-  AxiosError, 
+  type AxiosInstance,
+  AxiosError,
   InternalAxiosRequestConfig,
   AxiosResponse,
   Method,
@@ -30,6 +30,7 @@ axiosInstance.interceptors.request.use(
     }
     // eslint-disable-next-line no-param-reassign
     config.headers.Authorization = `Bearer ${accessToken}`;
+    console.log('토큰');
     return config;
   },
   (error: AxiosError) => {
@@ -52,7 +53,6 @@ const createApiMethod =
   (instance: AxiosInstance, method: Method) =>
   <T>(config: AxiosRequestConfig): Promise<BaseResponse<T>> =>
     instance({ ...config, method });
-
 
 export default {
   get: createApiMethod(axiosInstance, HTTP_METHODS.GET),

--- a/app/client-layout.tsx
+++ b/app/client-layout.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { RecoilRoot } from 'recoil';
+import { Header, Footer } from '@/components/common';
+
+export default function ClientLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <RecoilRoot>
+      <Header />
+      <main className="h-full mx-auto mt-10 w-desktop">{children}</main>
+      <Footer />
+    </RecoilRoot>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,7 @@
-import type { Metadata } from 'next';
-import { Header, Footer } from '@/components/common';
 import { QueryClientProvider, NextUIProvider } from '@/lib';
 import '@/styles/globals.css';
 import { inter } from '../public/fonts/fonts';
+import ClientLayout from './client-layout';
 
 export const metadata: Metadata = {
   title: 'K-POP Goods',
@@ -16,12 +15,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko" className="bg-background">
-      <body className={`${inter.variable} text-white h-full min-h-screen `}>
+      <body className={`${inter.variable} text-white h-full min-h-screen`}>
         <NextUIProvider>
           <QueryClientProvider>
-            <Header />
-            <main className="h-full mx-auto mt-10 w-desktop">{children}</main>
-            <Footer />
+            <ClientLayout>{children}</ClientLayout>
           </QueryClientProvider>
         </NextUIProvider>
       </body>

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -1,15 +1,50 @@
 'use client';
 
 import { useState, useCallback } from 'react';
+import { setCookies } from 'cookies-next';
+
 import { Input, Button } from '@nextui-org/react';
+import { useRecoilState } from 'recoil';
 import { IconEyeClosed, IconEyeOpen } from '@/public/svgs';
+import { postLogin } from '@/api/auth';
+import authState from '@/store/auth';
 
 export default function Signin() {
   const [isVisible, setIsVisible] = useState(false);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [auth, setAuth] = useRecoilState(authState);
 
   const toggleSwitch = useCallback(() => {
     setIsVisible(!isVisible);
   }, [isVisible]);
+
+  const handleLogin = async () => {
+    try {
+      const response = await postLogin({ userEmail: email, password });
+      // const accessToken = response.data?.loginUser.accessToken;
+      if (response.statusCode === 200) {
+        console.log(response.headers['authorization']);
+
+        if (response.statusCode === 200 && response.message === '로그인 성공') {
+          // const accessToken = response.headers['authorization'];
+          // const refreshToken = response.headers['authorization-refresh'];
+          // console.log(accessToken);
+          // setCookies('accessToken', accessToken);
+          // setCookies('refreshToken', refreshToken);
+          console.log(response);
+          setAuth({
+            isAuthenticated: true,
+            userEmail: email,
+          });
+        }
+      } else {
+        console.error('Login failed:', response.message);
+      }
+    } catch (error) {
+      console.error('Login failed:', error);
+    }
+  };
 
   return (
     <section className="flex flex-col items-center gap-8 my-10 ">
@@ -20,6 +55,8 @@ export default function Signin() {
         <Input
           type="email"
           placeholder="이메일 계정"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
           classNames={{
             inputWrapper: ['bg-component'],
           }}
@@ -31,8 +68,10 @@ export default function Signin() {
         <h3 className="font-semibold text-inactive">비밀번호</h3>
         <div className="flex flex-col gap-3">
           <Input
-            type={isVisible ? 'string' : 'password'}
+            type={isVisible ? 'text' : 'password'}
             placeholder="비밀번호 입력"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
             classNames={{
               inputWrapper: ['bg-component'],
             }}
@@ -42,14 +81,17 @@ export default function Signin() {
                 className="bg-transparent"
                 onClick={toggleSwitch}
               >
-                {isVisible ? <IconEyeClosed /> : <IconEyeOpen password />}
+                {isVisible ? <IconEyeClosed /> : <IconEyeOpen />}
               </Button>
             }
           />
         </div>
       </div>
 
-      <Button className="w-[480px] bg-themeBlue/20 border-themeBlue text-inactive h-14">
+      <Button
+        className="w-[480px] bg-themeBlue/20 border-themeBlue text-inactive h-14"
+        onClick={handleLogin}
+      >
         이메일 로그인하기
       </Button>
     </section>

--- a/components/common/Header/Header.tsx
+++ b/components/common/Header/Header.tsx
@@ -2,6 +2,8 @@
 
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
+import { useRecoilValue } from 'recoil';
+import authState from '@/store/auth';
 import {
   Navbar,
   NavbarBrand,
@@ -34,6 +36,7 @@ const items = [
 
 export default function Header() {
   const pathname = usePathname();
+  const auth = useRecoilValue(authState);
 
   return (
     <header className="h-16 mx-auto ">
@@ -67,22 +70,34 @@ export default function Header() {
         </NavbarContent>
 
         <NavbarContent justify="end" className="absolute right-[-127px] gap-7">
-          <NavbarItem key={4}>
-            {/* TODO: 로그인 기능 개발 후 수정 필요 */}
-            <Link href="/mypage" className="text-xl">
-              마이페이지
-            </Link>
-          </NavbarItem>
-          <NavbarItem>
-            <Link href="/signin" className="text-xl">
-              로그인
-            </Link>
-          </NavbarItem>
-          <NavbarItem>
-            <Link href="/signup" className="text-xl">
-              회원가입
-            </Link>
-          </NavbarItem>
+          {auth.isAuthenticated ? (
+            <>
+              <NavbarItem key={4}>
+                <Link href="/mypage" className="text-xl">
+                  마이페이지
+                </Link>
+              </NavbarItem>
+              <NavbarItem>
+                <span className="text-xl">환영합니다, {auth.userEmail}님</span>
+              </NavbarItem>
+              <NavbarItem>
+                <span className="text-xl">로그아웃</span>
+              </NavbarItem>
+            </>
+          ) : (
+            <>
+              <NavbarItem>
+                <Link href="/signin" className="text-xl">
+                  로그인
+                </Link>
+              </NavbarItem>
+              <NavbarItem>
+                <Link href="/signup" className="text-xl">
+                  회원가입
+                </Link>
+              </NavbarItem>
+            </>
+          )}
         </NavbarContent>
       </Navbar>
     </header>

--- a/store/auth.ts
+++ b/store/auth.ts
@@ -1,0 +1,16 @@
+import { atom } from 'recoil';
+
+interface AuthState {
+  isAuthenticated: boolean;
+  userEmail: string;
+}
+
+const authState = atom<AuthState>({
+  key: 'authState',
+  default: {
+    isAuthenticated: false,
+    userEmail: '',
+  },
+});
+
+export default authState;


### PR DESCRIPTION
## 1. 연관된 이슈 번호

- #48

<br>

## 2. 작업 내용

- [x] recoil코드 추가
- [x] 로그인 핸들러 추가

<br>
## 참고 자료 (선택사항)
https://velog.io/@xmun74/ReactTS-Header%EB%A1%9C-Token%EB%B0%9B%EA%B8%B0
해당 블로그 참고하여 헤더에 있는 
accessToken과
refreshToken을 받아오려 했으나 undefined값이 출력되는 문제가 있음


## 3. 스크린샷 (선택사항)
<br>
<img width="1352" alt="스크린샷 2024-05-22 오전 12 09 19" src="https://github.com/Kpop-Goods/Kg-FE/assets/111037279/914d8686-40d7-4db3-a63a-e9063b5488a3">

토큰 받아오는 코드 주석처리시
<img width="1350" alt="스크린샷 2024-05-22 오전 12 07 32" src="https://github.com/Kpop-Goods/Kg-FE/assets/111037279/120593d0-bf09-427d-bf8a-66db726a9701">

<img width="1382" alt="스크린샷 2024-05-22 오전 12 06 03" src="https://github.com/Kpop-Goods/Kg-FE/assets/111037279/3a3d7718-6a97-4cb0-9c87-7eb452db1b47">
